### PR TITLE
iterparse function need xml file to be parameter

### DIFF
--- a/xml_models/managers.py
+++ b/xml_models/managers.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 import xml_models.rest_client as rest_client
 from lxml import etree
 from xml_models.xpath_finder import MultipleNodesReturnedException
+from StringIO import StringIO
 
 
 class ModelManager(object):
@@ -142,7 +143,13 @@ class ModelQuery(object):
             return
 
         node_to_find = getattr(self.model, 'collection_node', None)
-        tree = etree.iterparse(xml, ['start', 'end'])
+        if isinstance(xml, basestring):
+            xml_file = StringIO()
+            xml_file.write(xml)
+            xml_file.seek(0)
+            tree = etree.iterparse(xml_file, ['start', 'end'])
+        else:
+            tree = etree.iterparse(xml, ['start', 'end'])
 
         _, child = next(tree)
 

--- a/xml_models/managers.py
+++ b/xml_models/managers.py
@@ -144,9 +144,7 @@ class ModelQuery(object):
 
         node_to_find = getattr(self.model, 'collection_node', None)
         if isinstance(xml, basestring):
-            xml_file = StringIO()
-            xml_file.write(xml)
-            xml_file.seek(0)
+            xml_file = StringIO(xml.encode())
             tree = etree.iterparse(xml_file, ['start', 'end'])
         else:
             tree = etree.iterparse(xml, ['start', 'end'])

--- a/xml_models/managers.py
+++ b/xml_models/managers.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import
 import xml_models.rest_client as rest_client
 from lxml import etree
 from xml_models.xpath_finder import MultipleNodesReturnedException
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 
 class ModelManager(object):


### PR DESCRIPTION
The `xml source data` we get usually are just `xml string`, before passing it to `etree.iterparse()`  and generating the xml tree, we need to covert it into `xml file type`, or the function will throw `IOError` coz it can not find the xml source.
