### PR TITLE
node may not exist, need to take care of when generating xml back

### DIFF
--- a/xml_models/xml_models.py
+++ b/xml_models/xml_models.py
@@ -295,8 +295,7 @@ class Model(with_metaclass(ModelBase)):
         xpath = "/".join(parts[:-1])  # I think it is safe to assume attributes are in the last place
         attr = parts[-1].replace('@', '')
 
-        if attr in self._get_tree().xpath(xpath)[0].attrib:
-            self._get_tree().xpath(xpath)[0].attrib[attr] = str(getattr(self, field._name))
+        self._get_tree().xpath(xpath)[0].attrib[attr] = str(getattr(self, field._name))
 
     def _update_subtree(self, field):
         """

--- a/xml_models/xml_models.py
+++ b/xml_models/xml_models.py
@@ -295,7 +295,8 @@ class Model(with_metaclass(ModelBase)):
         xpath = "/".join(parts[:-1])  # I think it is safe to assume attributes are in the last place
         attr = parts[-1].replace('@', '')
 
-        self._get_tree().xpath(xpath)[0].attrib[attr] = str(getattr(self, field._name))
+        if attr in self._get_tree().xpath(xpath)[0].attrib:
+            self._get_tree().xpath(xpath)[0].attrib[attr] = str(getattr(self, field._name))
 
     def _update_subtree(self, field):
         """
@@ -385,7 +386,9 @@ class Model(with_metaclass(ModelBase)):
         elif isinstance(field, OneToOneField):
             self._update_subtree(field)
         else:
-            self._get_tree().xpath(field.xpath)[0].text = str(getattr(self, field._name))
+            simple_node = self._get_tree().xpath(field.xpath)
+            if simple_node is not None and len(simple_node) > 0:
+                self._get_tree().xpath(field.xpath)[0].text = str(getattr(self, field._name))
 
     def _get_tree(self):
         if self._dom is None:


### PR DESCRIPTION
Models we defined are unified structure, however sometimes, in the source xml, collected nodes may not have the same structure, for example:
```
<AddressList>
	<Address id="1">
		  <number>22</number>
		  <street>Acacia Avenue</street>
		  <city size="big">Maiden</city>
		  <country>England</country>
		  <postcode>IM6 66B</postcode>
	</Address>
	<Address id="2">
		  <number>22</number>
          <street>Acacia Avenue</street>
		  <street>Acacia Avenue</street>
		  <city>Maiden</city>
	</Address>
</AddressList>
```
address \#2 do not have the  `postcode` node and node `city` under `address` do not have a `size` attribute, and when these two(node `postcode` and attribute `size`) are defined in models, errors will be thrown while generating xml back(thus call to_xml() api), also the generated xml will not the same as the original xml.