### PR TITLE
fixed subpackage "rest_client" is not included in xml_model2 package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     author='Geoff Ford and Chris Tarttelin and Cam McHugh',
     author_email='g_ford@hotmail.ccom',
     url='http://github.com/alephnullplex/xml_models',
-    packages=['xml_models'],
+    packages=['xml_models', 'xml_models.rest_client'],
     install_requires=['lxml', 'python-dateutil', 'pytz', 'future', 'requests'],
     tests_require=['mock', 'nose', 'coverage'],
     test_suite="nose.collector"


### PR DESCRIPTION
Right now, package `xml_models2` generated by `setuptools` does not include subpackage `rest_client`.