### PR TITLE
avoid changing Class Model in metaclass ModelBase

### DIFF
--- a/xml_models/xml_models.py
+++ b/xml_models/xml_models.py
@@ -207,6 +207,9 @@ class ModelBase(type):
     """
 
     def __new__(mcs, name, bases, attrs):
+        if name == 'Model':
+            return type.__new__(mcs, name, bases, attrs)
+
         new_class = super(ModelBase, mcs).__new__(mcs, name, bases, attrs)
         xml_fields = [field_name for field_name in attrs.keys() if isinstance(attrs[field_name], BaseField)]
         setattr(new_class, 'xml_fields', xml_fields)


### PR DESCRIPTION
There is no need to change class `Model`, we only need to change those classes we defined using this metaclass--`ModelBase`, (those classes we defined will automatically look and find the `metaclass` setting in its base class `Model`, and complete the serialization job)